### PR TITLE
NOSTORY: added feature for including managed policy arns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - feat: constraints in iam policy
 
+## [1.0.4] - 2022-07-21
+### Changes
+- feat: Introduced feature for adding AWS Managed Policy ARNs
+
 ## [1.0.3] - 2022-06-30
 ### Changes
 - Added the `.github/workflow` folder (not supposed to run gitcommit)
@@ -38,3 +42,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.1]: https://github.com/boldlink/terraform-aws-iam-group/releases/tag/1.0.1
 [1.0.2]: https://github.com/boldlink/terraform-aws-iam-group/releases/tag/1.0.2
 [1.0.3]: https://github.com/boldlink/terraform-aws-iam-group/releases/tag/1.0.3
+[1.0.4]: https://github.com/boldlink/terraform-aws-iam-group/releases/tag/1.0.4

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ No modules.
 | [aws_iam_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
 | [aws_iam_group_membership.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_membership) | resource |
 | [aws_iam_group_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy) | resource |
+| [aws_iam_group_policy_attachment.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 
 ## Inputs
 
@@ -59,6 +60,7 @@ No modules.
 | <a name="input_group_path"></a> [group\_path](#input\_group\_path) | (Optional, default `/`) Path in which to create the group. | `string` | `"/"` | no |
 | <a name="input_group_policy"></a> [group\_policy](#input\_group\_policy) | (Required) The policy document. This is a JSON formatted string. | `string` | `null` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | (Required) A list of IAM User names to associate with the Group | `list(string)` | `[]` | no |
+| <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | (Optional) Set of exclusive AWS IAM managed policy ARNs to attach to the IAM UserGroup. | `list(string)` | `[]` | no |
 | <a name="input_membership_name"></a> [membership\_name](#input\_membership\_name) | (Required) The name to identify the Group Membership | `string` | `null` | no |
 | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | (Optional) The name of the policy. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
 | <a name="input_policy_name_prefix"></a> [policy\_name\_prefix](#input\_policy\_name\_prefix) | (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`. | `string` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,6 +30,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -1,3 +1,7 @@
+data "aws_iam_policy" "billing" {
+  arn = "arn:aws:iam::aws:policy/job-function/Billing"
+}
+
 data "aws_iam_policy_document" "default" {
 
   statement {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,6 +22,9 @@ module "iam_group" {
   group_users     = [module.iam_user.user_name]
   membership_name = local.name
   policy_name     = local.name
+  managed_policy_arns = [
+    data.aws_iam_policy.billing.arn
+  ]
   group_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/main.tf
+++ b/main.tf
@@ -17,3 +17,10 @@ resource "aws_iam_group_policy" "main" {
   policy      = var.group_policy
   name_prefix = var.policy_name_prefix
 }
+
+### Purposely added to attach AWS Managed Policy ARNs to created group
+resource "aws_iam_group_policy_attachment" "main" {
+  count      = length(var.managed_policy_arns)
+  group      = aws_iam_group.main.name
+  policy_arn = var.managed_policy_arns[count.index]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "policy_name_prefix" {
   description = "(Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`."
   default     = null
 }
+
+variable "managed_policy_arns" {
+  type        = list(string)
+  description = "(Optional) Set of exclusive AWS IAM managed policy ARNs to attach to the IAM UserGroup."
+  default     = []
+}


### PR DESCRIPTION
# Description

This PR has been created to add feature for attaching managed policies to group(s)

## Features/Fixes/Patches/Changes list:

Please check the [v1.0.4 CHANGELOG.md](https://github.com/boldlink/terraform-aws-iam-group/blob/feature/add-managed-policy-arns/CHANGELOG.md#104---2022-07-21)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [ ] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
